### PR TITLE
add dependencies to Imports

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,6 +6,10 @@ Author: Stephanie Hicks, Kwame Okrah, Hector Corrado Bravo and Rafael Irizarry
 Maintainer: Stephanie Hicks <stephaniechicks@gmail.com>
 Imports:
     Biobase,
+    minfi,
+    doParallel,
+    foreach,
+    iterators
 Depends:
     R (>= 3.1.2)
 Suggests:


### PR DESCRIPTION
I could not install successfully, because these were not listed in the "Imports" section:

    minfi, doParallel, foreach, iterators